### PR TITLE
adding bias field extraction for FAST results

### DIFF
--- a/oxasl/struc.py
+++ b/oxasl/struc.py
@@ -115,6 +115,11 @@ def segment(wsp):
             wsp.structural.csf_pv = Image("%s_pve_0" % wsp.fastsrc)
             wsp.structural.gm_pv = Image("%s_pve_1" % wsp.fastsrc)
             wsp.structural.wm_pv = Image("%s_pve_2" % wsp.fastsrc)
+            try:
+                wsp.structural.bias = Image("%s_bias" % wsp.fastsrc))
+                wsp.log.write(" - Bias field extracted successfully\n")
+            except PathError:
+                wsp.log.write("- No bias field found")
         elif wsp.structural.struc:
             wsp.log.write(" - Running FAST\n")
             page.text("FAST run to segment structural image")


### PR DESCRIPTION
There was missing logic for extracting the bias field from user-provided FAST segmentation results, preventing the completion of sensitivity correction. This commit adds that logic in so that FAST can be used as an alternative to fsl_anat for T1 preprocessing.